### PR TITLE
Fix wrong args order of enableAutostart on windows.

### DIFF
--- a/lib/win32.js
+++ b/lib/win32.js
@@ -26,7 +26,7 @@ function isAutostartEnabled(key, callback) {
   callback(err, fileExists(`${getWinStartupPath()}/${key}.bat`));
 }
 
-function enableAutostart(key, path, command, callback) {
+function enableAutostart(key, command, path, callback) {
   isAutostartEnabled(key, (error, isEnabled) => {
     if (error) {
       callback(error);


### PR DESCRIPTION
arg of enableAutostart on win32  is not compatible with linux or darwin.
This PR fix it.